### PR TITLE
Add optional route.bible QR overlay for Bible verse presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,15 @@
 
 A free and open source presentation software package for Churches, providing display of Bible verses, songs, notifications, and custom slides to a secondary displays, typically a projector, monitor or television.
 
+## Optional Route Bible QR for Bible slides
+
+Praisenter can optionally show a Route Bible QR overlay on Bible verse presentation slides.
+
+* Open `Settings -> Bible`
+* Turn on `Show Route Bible QR`
+* Bible verse presentation slides will render a bottom-right QR overlay
+* Songs, notifications, and other non-Bible slides stay unchanged
+
 ## Requirements:
 * Windows 10 x64 22H2 or higher (most testing occurs on Windows 11)
 * Ubuntu 22.04 x64 or higher
@@ -189,4 +198,3 @@ This will convert the folder of images into an iconset, this can be verified by 
 1. Navigate to the directory containing your `icon.iconset` in the terminal
 2. Run `iconutil` with the following command: `iconutil -c icns icon.iconset`
 3. Your `icon.icns` will be generated in the current directory
-

--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@
 
 A free and open source presentation software package for Churches, providing display of Bible verses, songs, notifications, and custom slides to a secondary displays, typically a projector, monitor or television.
 
-## Optional Route Bible QR for Bible slides
+## Optional route.bible QR for Bible slides
 
-Praisenter can optionally show a Route Bible QR overlay on Bible verse presentation slides.
+Praisenter can optionally show a route.bible QR overlay on Bible verse presentation slides.
 
 * Open `Settings -> Bible`
-* Turn on `Show Route Bible QR`
+* Turn on `Show route.bible QR`
 * Bible verse presentation slides will render a bottom-right QR overlay
 * Songs, notifications, and other non-Bible slides stay unchanged
 

--- a/src/main/java/org/praisenter/data/workspace/ReadOnlyWorkspaceConfiguration.java
+++ b/src/main/java/org/praisenter/data/workspace/ReadOnlyWorkspaceConfiguration.java
@@ -17,6 +17,7 @@ public interface ReadOnlyWorkspaceConfiguration extends MediaConfiguration, Slid
 	
 	public boolean isRenumberBibleWarningEnabled();
 	public boolean isReorderBibleWarningEnabled();
+	public boolean isRouteBibleQrEnabled();
 	
 	public String getLanguageTag();
 	public String getThemeName();
@@ -40,6 +41,7 @@ public interface ReadOnlyWorkspaceConfiguration extends MediaConfiguration, Slid
 	
 	public ReadOnlyBooleanProperty renumberBibleWarningEnabledProperty();
 	public ReadOnlyBooleanProperty reorderBibleWarningEnabledProperty();
+	public ReadOnlyBooleanProperty routeBibleQrEnabledProperty();
 	
 	public ReadOnlyIntegerProperty thumbnailWidthProperty();
 	public ReadOnlyIntegerProperty thumbnailHeightProperty();

--- a/src/main/java/org/praisenter/data/workspace/WorkspaceConfiguration.java
+++ b/src/main/java/org/praisenter/data/workspace/WorkspaceConfiguration.java
@@ -43,6 +43,7 @@ public final class WorkspaceConfiguration implements ReadOnlyWorkspaceConfigurat
 	
 	private final BooleanProperty renumberBibleWarningEnabled;
 	private final BooleanProperty reorderBibleWarningEnabled;
+	private final BooleanProperty routeBibleQrEnabled;
 	
 	private final IntegerProperty thumbnailWidth;
 	private final IntegerProperty thumbnailHeight;
@@ -85,6 +86,7 @@ public final class WorkspaceConfiguration implements ReadOnlyWorkspaceConfigurat
 		
 		this.renumberBibleWarningEnabled = new SimpleBooleanProperty(true);
 		this.reorderBibleWarningEnabled = new SimpleBooleanProperty(true);
+		this.routeBibleQrEnabled = new SimpleBooleanProperty(false);
 		
 		this.thumbnailWidth = new SimpleIntegerProperty(Constants.THUMBNAIL_SIZE);
 		this.thumbnailHeight = new SimpleIntegerProperty(Constants.THUMBNAIL_SIZE);
@@ -240,6 +242,22 @@ public final class WorkspaceConfiguration implements ReadOnlyWorkspaceConfigurat
 	@Override
 	public BooleanProperty reorderBibleWarningEnabledProperty() {
 		return this.reorderBibleWarningEnabled;
+	}
+
+	@Override
+	@JsonProperty
+	public boolean isRouteBibleQrEnabled() {
+		return this.routeBibleQrEnabled.get();
+	}
+
+	@JsonProperty
+	public void setRouteBibleQrEnabled(boolean enabled) {
+		this.routeBibleQrEnabled.set(enabled);
+	}
+
+	@Override
+	public BooleanProperty routeBibleQrEnabledProperty() {
+		return this.routeBibleQrEnabled;
 	}
 
 	@Override

--- a/src/main/java/org/praisenter/ui/pages/SettingsPage.java
+++ b/src/main/java/org/praisenter/ui/pages/SettingsPage.java
@@ -278,7 +278,7 @@ public final class SettingsPage extends BorderPane implements Page {
 			configuration.setReorderBibleWarningEnabled(nv);
 		});
 
-		// Route Bible QR
+		// route.bible QR
 		ToggleSwitch tglRouteBibleQr = new ToggleSwitch();
 		tglRouteBibleQr.setSelected(configuration.isRouteBibleQrEnabled());
 		tglRouteBibleQr.selectedProperty().addListener((obs, ov, nv) -> {
@@ -351,7 +351,7 @@ public final class SettingsPage extends BorderPane implements Page {
 		Tile tleBibleReorderWarning = new Tile(Translations.get("settings.bible.reorderWarning"), Translations.get("settings.bible.reorderWarning.description"));
 		tleBibleReorderWarning.setAction(tglBibleReorderWarning);
 		tleBibleReorderWarning.setActionHandler(tglBibleReorderWarning::fire);
-		Tile tleRouteBibleQr = new Tile("Show Route Bible QR", "Adds an optional Route Bible QR overlay to Bible verse presentation slides only.");
+		Tile tleRouteBibleQr = new Tile("Show route.bible QR", "Adds an optional route.bible QR overlay to Bible verse presentation slides only.");
 		tleRouteBibleQr.setAction(tglRouteBibleQr);
 		tleRouteBibleQr.setActionHandler(tglRouteBibleQr::fire);
 		VBox boxBible = new VBox(lblBible, new Separator(Orientation.HORIZONTAL), tleBibleRenumberWarning, tleBibleReorderWarning, tleRouteBibleQr);

--- a/src/main/java/org/praisenter/ui/pages/SettingsPage.java
+++ b/src/main/java/org/praisenter/ui/pages/SettingsPage.java
@@ -277,6 +277,13 @@ public final class SettingsPage extends BorderPane implements Page {
 		tglBibleReorderWarning.selectedProperty().addListener((obs, ov, nv) -> {
 			configuration.setReorderBibleWarningEnabled(nv);
 		});
+
+		// Route Bible QR
+		ToggleSwitch tglRouteBibleQr = new ToggleSwitch();
+		tglRouteBibleQr.setSelected(configuration.isRouteBibleQrEnabled());
+		tglRouteBibleQr.selectedProperty().addListener((obs, ov, nv) -> {
+			configuration.setRouteBibleQrEnabled(nv);
+		});
 		
 		// debug mode
 		ToggleSwitch tglDebugMode = new ToggleSwitch();
@@ -344,7 +351,10 @@ public final class SettingsPage extends BorderPane implements Page {
 		Tile tleBibleReorderWarning = new Tile(Translations.get("settings.bible.reorderWarning"), Translations.get("settings.bible.reorderWarning.description"));
 		tleBibleReorderWarning.setAction(tglBibleReorderWarning);
 		tleBibleReorderWarning.setActionHandler(tglBibleReorderWarning::fire);
-		VBox boxBible = new VBox(lblBible, new Separator(Orientation.HORIZONTAL), tleBibleRenumberWarning, tleBibleReorderWarning);
+		Tile tleRouteBibleQr = new Tile("Show Route Bible QR", "Adds an optional Route Bible QR overlay to Bible verse presentation slides only.");
+		tleRouteBibleQr.setAction(tglRouteBibleQr);
+		tleRouteBibleQr.setActionHandler(tglRouteBibleQr::fire);
+		VBox boxBible = new VBox(lblBible, new Separator(Orientation.HORIZONTAL), tleBibleRenumberWarning, tleBibleReorderWarning, tleRouteBibleQr);
 
 		Label lblMedia = new Label(Translations.get("settings.media"));
 		lblMedia.getStyleClass().add(Styles.TITLE_3);

--- a/src/main/java/org/praisenter/ui/slide/RouteBibleQrOverlay.java
+++ b/src/main/java/org/praisenter/ui/slide/RouteBibleQrOverlay.java
@@ -1,0 +1,38 @@
+package org.praisenter.ui.slide;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.praisenter.data.TextItem;
+import org.praisenter.data.TextStore;
+import org.praisenter.data.TextType;
+import org.praisenter.data.TextVariant;
+import org.praisenter.data.bible.BibleReferenceTextStore;
+
+final class RouteBibleQrOverlay {
+	private RouteBibleQrOverlay() {}
+
+	static String buildQrUrl(String referenceLabel) {
+		String encodedReferenceLabel = URLEncoder.encode(referenceLabel, StandardCharsets.UTF_8);
+		return "https://route.bible/qr?passage="
+			+ encodedReferenceLabel
+			+ "&format=png&size=256&utm_source=praisenter&utm_medium=qr&mode=launcher";
+	}
+
+	static String getReferenceLabel(TextStore data) {
+		if (!(data instanceof BibleReferenceTextStore)) {
+			return null;
+		}
+
+		TextItem title = data.get(TextVariant.PRIMARY, TextType.TITLE);
+		if (title == null || title.getText() == null || title.getText().isBlank()) {
+			return null;
+		}
+
+		return title.getText();
+	}
+
+	static boolean shouldShow(boolean enabled, TextStore data, SlideMode mode) {
+		return enabled && mode == SlideMode.PRESENT && getReferenceLabel(data) != null;
+	}
+}

--- a/src/main/java/org/praisenter/ui/slide/SlideNode.java
+++ b/src/main/java/org/praisenter/ui/slide/SlideNode.java
@@ -11,10 +11,16 @@ import org.praisenter.ui.bind.MappedList2;
 import javafx.beans.binding.Bindings;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import javafx.geometry.Insets;
+import javafx.geometry.Pos;
+import javafx.scene.image.Image;
+import javafx.scene.image.ImageView;
 import javafx.scene.layout.Pane;
+import javafx.scene.layout.StackPane;
 
 final class SlideNode extends SlideRegionNode<Slide> implements Playable {
 	private final Pane components;
+	private final ImageView routeBibleQr;
 	private final MappedList2<SlideComponentNode<?>, SlideComponent> mapping;
 	private final ObservableList<SlideComponentNode<?>> mappingUnmodifiable;
 	
@@ -38,8 +44,40 @@ final class SlideNode extends SlideRegionNode<Slide> implements Playable {
 		});
 		Bindings.bindContent(this.components.getChildren(), this.mapping);
 		this.mappingUnmodifiable = FXCollections.unmodifiableObservableList(this.mapping);
-		
-		this.content.getChildren().add(this.components);
+
+		this.routeBibleQr = new ImageView();
+		this.routeBibleQr.setFitWidth(112);
+		this.routeBibleQr.setFitHeight(112);
+		this.routeBibleQr.setPreserveRatio(true);
+		this.routeBibleQr.setSmooth(true);
+		this.routeBibleQr.managedProperty().bind(this.routeBibleQr.visibleProperty());
+		this.routeBibleQr.visibleProperty().bind(Bindings.createBooleanBinding(() -> {
+			return RouteBibleQrOverlay.shouldShow(
+				context.getWorkspaceConfiguration().isRouteBibleQrEnabled(),
+				region.getPlaceholderData(),
+				this.mode.get()
+			);
+		}, region.placeholderDataProperty(), context.getWorkspaceConfiguration().routeBibleQrEnabledProperty(), this.mode));
+		this.routeBibleQr.imageProperty().bind(Bindings.createObjectBinding(() -> {
+			if (!RouteBibleQrOverlay.shouldShow(
+				context.getWorkspaceConfiguration().isRouteBibleQrEnabled(),
+				region.getPlaceholderData(),
+				this.mode.get()
+			)) {
+				return null;
+			}
+
+			String referenceLabel = RouteBibleQrOverlay.getReferenceLabel(region.getPlaceholderData());
+			if (referenceLabel == null) {
+				return null;
+			}
+
+			return new Image(RouteBibleQrOverlay.buildQrUrl(referenceLabel), 112, 112, true, true, true);
+		}, region.placeholderDataProperty(), context.getWorkspaceConfiguration().routeBibleQrEnabledProperty(), this.mode));
+		StackPane.setAlignment(this.routeBibleQr, Pos.BOTTOM_RIGHT);
+		StackPane.setMargin(this.routeBibleQr, new Insets(16));
+
+		this.content.getChildren().addAll(this.components, this.routeBibleQr);
 	}
 
 	@Override

--- a/src/test/java/org/praisenter/ui/slide/RouteBibleQrOverlayTest.java
+++ b/src/test/java/org/praisenter/ui/slide/RouteBibleQrOverlayTest.java
@@ -1,0 +1,63 @@
+package org.praisenter.ui.slide;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.UUID;
+
+import org.junit.jupiter.api.Test;
+import org.praisenter.data.StringTextStore;
+import org.praisenter.data.TextVariant;
+import org.praisenter.data.bible.BibleReferenceTextStore;
+import org.praisenter.data.bible.BibleReferenceVerse;
+
+class RouteBibleQrOverlayTest {
+	@Test
+	void buildsTheExpectedQrUrl() {
+		assertEquals(
+			"https://route.bible/qr?passage=Psalm+23&format=png&size=256&utm_source=praisenter&utm_medium=qr&mode=launcher",
+			RouteBibleQrOverlay.buildQrUrl("Psalm 23")
+		);
+	}
+
+	@Test
+	void showsTheOverlayOnlyForBiblePresentationContentWhenEnabled() {
+		assertTrue(
+			RouteBibleQrOverlay.shouldShow(true, createBibleData("John 3:16"), SlideMode.PRESENT)
+		);
+		assertFalse(
+			RouteBibleQrOverlay.shouldShow(false, createBibleData("John 3:16"), SlideMode.PRESENT)
+		);
+		assertFalse(
+			RouteBibleQrOverlay.shouldShow(true, createBibleData("John 3:16"), SlideMode.VIEW)
+		);
+		assertFalse(
+			RouteBibleQrOverlay.shouldShow(true, new StringTextStore("Song verse"), SlideMode.PRESENT)
+		);
+	}
+
+	@Test
+	void extractsTheDisplayedBibleReferenceLabel() {
+		assertEquals("1 John 4:7", RouteBibleQrOverlay.getReferenceLabel(createBibleData("1 John 4:7")));
+	}
+
+	private static BibleReferenceTextStore createBibleData(String referenceLabel) {
+		String[] parts = referenceLabel.split(" ");
+		String bookName = String.join(" ", java.util.Arrays.copyOf(parts, parts.length - 1));
+		String[] chapterVerse = parts[parts.length - 1].split(":");
+		BibleReferenceTextStore store = new BibleReferenceTextStore();
+		store.getVariant(TextVariant.PRIMARY).getReferenceVerses().add(
+			new BibleReferenceVerse(
+				UUID.randomUUID(),
+				"KJV",
+				bookName,
+				19,
+				Integer.parseInt(chapterVerse[0]),
+				Integer.parseInt(chapterVerse[1]),
+				"The Lord is my shepherd"
+			)
+		);
+		return store;
+	}
+}


### PR DESCRIPTION
## Summary
- adds an optional `Show route.bible QR` Bible setting for presentation slides
- keeps the feature off by default and preserves current Bible, song, queue, and notification behavior
- scopes the overlay to Bible verse presentation only

## Implementation
- adds a persisted workspace configuration flag for route.bible QR
- adds a Bible settings toggle in the settings page
- renders a bottom-right 112px PNG route.bible QR overlay from the displayed Bible reference label only when presenting Bible placeholder data
- keeps songs and other non-Bible slide content out of scope by construction
- adds focused unit tests and a short README note

## Validation
- Added JUnit coverage for QR URL building and Bible-only overlay gating
- Local execution of Maven tests was not possible in this environment because Maven is not installed here

## Post-Deploy Monitoring & Validation
No additional operational monitoring required because this change only normalizes user-visible route.bible branding copy in docs and settings text.
